### PR TITLE
wait for a lock released by BLPOP instead of polling.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,6 @@ perl:
   - 5.12
   - 5.14
   - 5.16
-
+env:
+  - WAIT_QUEUE=0
+  - WAIT_QUEUE=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ services:
   - redis-server
 perl:
   - 5.12
-  - 5.14
   - 5.16
+  - 5.24
 env:
   - WAIT_QUEUE=0
   - WAIT_QUEUE=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: perl
+services:
+  - redis-server
 perl:
   - 5.12
   - 5.14

--- a/t/01_single.t
+++ b/t/01_single.t
@@ -54,6 +54,7 @@ subtest "set expires and keep lock" => sub {
 subtest "wait for lock expired" => sub {
     my ($code, $elapsed) = redis_setlock(
         "--redis"   => "127.0.0.1:$port",
+        "--expires" => 4,
         $lock_key,
         "perl", "-e", "exit 0",
     );

--- a/t/Util.pm
+++ b/t/Util.pm
@@ -11,6 +11,8 @@ use Time::HiRes qw/ sleep gettimeofday tv_interval /;
 use Exporter 'import';
 our @EXPORT_OK = qw/ redis_server redis_setlock /;
 
+$Redis::Setlock::WAIT_QUEUE = $ENV{WAIT_QUEUE};
+
 sub redis_server {
     my $redis_server;
     my $port = empty_port();


### PR DESCRIPTION
When `$Redis::Setlock::WAIT_QUEUE` is true, Wait for a lock released using `BLPOP` command instead of polling;