### PR TITLE
add the lock key to warnings.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         perl:
           - "5.40.0"
-          - "5.12.1"
+          - "5.16.1"
     name: Perl ${{ matrix.perl }}
     steps:
       - run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         perl:
-          - "5.32.0"
+          - "5.40.0"
           - "5.12.1"
     name: Perl ${{ matrix.perl }}
     steps:

--- a/lib/Redis/Setlock.pm
+++ b/lib/Redis/Setlock.pm
@@ -97,9 +97,9 @@ sub lock_guard {
     return Guard::guard {
         my $elapsed = Time::HiRes::tv_interval($start);
         if ($opt->{expires} < $elapsed) {
-            warnf "guard(token:%s) seems to be already expired. elasped %s sec", $token, $elapsed;
+            warnf "guard(key:%s token:%s) seems to be already expired. elasped %s sec", $key, $token, $elapsed;
         } elsif (0 < $WARN_LOCK_TIME_THRESHOLD && $WARN_LOCK_TIME_THRESHOLD < $elapsed) {
-            warnf "guard(token:%s) elasped %s sec", $token, $elapsed;
+            warnf "guard(key:%s token:%s) elasped %s sec", $key, $token, $elapsed;
         }
         release_lock($redis, $opt, $key, $token);
     };


### PR DESCRIPTION
This pull request includes updates to the Perl version in the GitHub Actions workflow and improvements to the logging messages in the `lock_guard` subroutine in the `Redis::Setlock` module.

Updates to GitHub Actions workflow:

* [`.github/workflows/test.yaml`](diffhunk://#diff-245392b692a50c38ecab4381b118862db514035c10983f3bd4f4b7f1f4be4692L12-R12): Updated the Perl version from `5.32.0` to `5.40.0` in the matrix strategy.

Improvements to logging messages:

* [`lib/Redis/Setlock.pm`](diffhunk://#diff-faaf517b3a63221c5903fbb6f59d9c9ebeb566849404bd33e3c05f6534886f66L100-R102): Enhanced the logging messages in the `lock_guard` subroutine to include the `key` along with the `token` for better traceability.